### PR TITLE
fix bugs in if statement

### DIFF
--- a/md2rst_pandoc.sh
+++ b/md2rst_pandoc.sh
@@ -7,9 +7,9 @@ fi
 
 TARGET=/tmp/target.rst
 
-pandoc $1 -f markdown -t rst -o ${TARGET}
+pandoc "$1" -f markdown -t rst -o ${TARGET}
 
-if [ $? == 0 ];then
+if [ $? = 0 ];then
 	echo "The pandoc convertion is successful! Please check $TARGET!"
 else
 	echo "The pandoc covertion fails!"

--- a/rst2md_pandoc.sh
+++ b/rst2md_pandoc.sh
@@ -7,9 +7,9 @@ fi
 
 TARGET=/tmp/target.md
 
-pandoc $1 -f rst -t markdown -o ${TARGET}
+pandoc "$1" -f rst -t markdown -o ${TARGET}
 
-if [ $? == 0 ];then
+if [ $? = 0 ];then
 	echo "The pandoc convertion is successful! Please check $TARGET!"
 else
 	echo "The pandoc covertion fails!"


### PR DESCRIPTION
### **This pr fixs if statement bug in script and follows the SC rules**

An error occured when I try to convert rst to md
```
(base) ➜  hctt-scripts git:(master) ✗ ./rst2md_pandoc.sh ./kcov.rst
./rst2md_pandoc.sh: 12: [: 0: unexpected operator
The pandoc covertion fails!
```
`shellcheck` result as follows:
```
(base) ➜  hctt-scripts git:(master) ✗ shellcheck rst2md_pandoc.sh

In rst2md_pandoc.sh line 10:
pandoc $1 -f rst -t markdown -o ${TARGET}
       ^-- SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
pandoc "$1" -f rst -t markdown -o ${TARGET}


In rst2md_pandoc.sh line 12:
if [ $? == 0 ];then
     ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
        ^-- SC2039: In POSIX sh, == in place of = is undefined.

For more information:
  https://www.shellcheck.net/wiki/SC2039 -- In POSIX sh, == in place of = is ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...
```  