### PR TITLE
fix(submit2hctt.sh): correct arithmetic comparison for date validation

### DIFF
--- a/submit2hctt.sh
+++ b/submit2hctt.sh
@@ -19,7 +19,7 @@ validate() {
         echo "\033[31mFill metadata \"translated_date\" before commit!\033[0m"
         exit 1
     fi
-    if [ "$(("$translated_date" - "$collected_date"))" -lt 0 ];then
+    if [ $((translated_date - collected_date)) -lt 0 ]; then
         echo "\033[31mThe \"translated_date\" should be later than \"collected_date\"!\033[0m"
         exit 1
     fi


### PR DESCRIPTION
Fixes #8

## Summary
Fix shell portability error in date validation causing `/bin/sh: syntax error: operand expected` on macOS.

## Changes
- Replace quoted arithmetic expansion with POSIX-compliant form:
<pre lang="diff">
- if [ "$(("$translated_date" - "$collected_date"))" -lt 0 ]; then
+ if [ $((translated_date - collected_date)) -lt 0 ]; then
</pre>

## Rationale
Avoids quoted/empty operands in test expressions; works reliably across POSIX shells.

## Test Plan
- macOS 15.6.1: verified both success and failure paths behave as expected.